### PR TITLE
Remove unsupported networks

### DIFF
--- a/projects/BitbondLockers/config.json
+++ b/projects/BitbondLockers/config.json
@@ -6,10 +6,8 @@
     "blast": "blast",
     "bsc": "bsc",
     "ethereum": "ethereum",
-    "fantom": "fantom",
     "optimism": "optimism",
-    "polygon": "polygon",
-    "polygon_zkevm": "polygon-zkevm"
+    "polygon": "polygon"
   },
   "metisBaseUrl": "https://metis.bitbond.com/api/defillama",
   "userAgents": [

--- a/projects/BitbondSales/config.json
+++ b/projects/BitbondSales/config.json
@@ -6,10 +6,8 @@
     "blast": "blast",
     "bsc": "bsc",
     "ethereum": "ethereum",
-    "fantom": "fantom",
     "optimism": "optimism",
-    "polygon": "polygon",
-    "polygon_zkevm": "polygon-zkevm"
+    "polygon": "polygon"
   },
   "metisBaseUrl": "https://metis.bitbond.com/api/defillama",
   "userAgents": [


### PR DESCRIPTION
Polygon zkEVM and Fantom are no more supported by our Token Tool dApp.